### PR TITLE
Ensure Spot is presented full screen

### DIFF
--- a/Spot/Spot.swift
+++ b/Spot/Spot.swift
@@ -98,7 +98,8 @@ public class Spot: NSObject {
     static func loadViewControllers(withScreenshot screenshot: UIImage) {
         guard let initialViewController = loadSpotViewController() else { return }
         guard let topViewController = topViewController() else { return }
-        
+        initialViewController.modalPresentationStyle = .overFullScreen
+        initialViewController.modalTransitionStyle = .crossDissolve
         
         initialViewController.orientationToLock = UIDevice.current.orientation
         if ((topViewController as? OrientationLockNavigationController) != nil) {


### PR DESCRIPTION
It currently uses the default which from iOS 13 is a card-style modal and the drawing doesn't work as the pan gesture takes precedence.